### PR TITLE
Fix for hashLocation class

### DIFF
--- a/src/vanilla/hashLocation.ts
+++ b/src/vanilla/hashLocation.ts
@@ -18,6 +18,10 @@ export class HashLocationService implements LocationServices, Disposable {
   _location: LocationLike;
   _history: HistoryLike;
 
+  constructor() {
+    this._location = location;
+  }
+
   _getHash = () => trimHashVal(this._location.hash);
   _setHash = (val) => this._location.hash = val;
 


### PR DESCRIPTION
Fixes error caught by unit tests ‘Cannot set property of undefined’. The
class property needs to be initialized before usage.